### PR TITLE
範囲設置メニュー修正

### DIFF
--- a/src/com/github/unchama/buildassist/PlayerData.java
+++ b/src/com/github/unchama/buildassist/PlayerData.java
@@ -42,7 +42,7 @@ public class PlayerData {
 			flytime = 0;
 			Endlessfly = false;
 			ZoneSetSkillFlag = false;
-			zsSkillDirtFlag = false;
+			zsSkillDirtFlag = true;
 			AREAint = 2;
 
 			line_up_flg = 0;

--- a/src/com/github/unchama/buildassist/PlayerInventoryListener.java
+++ b/src/com/github/unchama/buildassist/PlayerInventoryListener.java
@@ -1,10 +1,7 @@
 package com.github.unchama.buildassist;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.UUID;
-
-import net.md_5.bungee.api.ChatColor;
 
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -20,6 +17,8 @@ import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 
 import com.github.unchama.seichiassist.SeichiAssist;
+
+import net.md_5.bungee.api.ChatColor;
 
 public class PlayerInventoryListener implements Listener {
 	HashMap<UUID,PlayerData> playermap = BuildAssist.playermap;
@@ -144,11 +143,14 @@ public class PlayerInventoryListener implements Listener {
 				}
 
 
-			} else if (itemstackcurrent.getType().equals(Material.SKULL_ITEM)){
-				//ホームメニューへ帰還
+			} else if (itemstackcurrent.getType().equals(Material.SKULL_ITEM) && itemstackcurrent.getItemMeta().getDisplayName().contains("「範囲設置スキル」設定画面へ")){
+				//範囲設置スキル設定画面を開く
 				player.playSound(player.getLocation(), Sound.BLOCK_FENCE_GATE_OPEN, 1, (float) 0.1);
-				player.openInventory(MenuInventoryData.getSetBlockSkillData(player));
-
+				if(playerdata.level < BuildAssist.config.getblocklineuplevel() ){
+					player.sendMessage(ChatColor.RED + "建築LVが足りません") ;
+				}else{
+					player.openInventory(MenuInventoryData.getSetBlockSkillData(player));
+				}
 			} else if (itemstackcurrent.getType().equals(Material.WOOD)){
 				//ブロックを並べるスキル設定
 				if(playerdata.level < BuildAssist.config.getblocklineuplevel() ){
@@ -178,8 +180,8 @@ public class PlayerInventoryListener implements Listener {
 			}
 
 
-			
-			
+
+
 		}
 		//インベントリ名が以下の時処理
 		if(topinventory.getTitle().equals(ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + "「範囲設置スキル」設定画面")){
@@ -244,15 +246,20 @@ public class PlayerInventoryListener implements Listener {
 				}
 			} else if (itemstackcurrent.getType().equals(Material.STONE)){
 				//範囲設置スキル ON/OFF
+				//範囲設置スキル ON/OFF
 				player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
-				if(playerdata.ZoneSetSkillFlag == false){
-					playerdata.ZoneSetSkillFlag = true ;
-					player.sendMessage(ChatColor.RED + "範囲設置スキルON" ) ;
-					player.openInventory(MenuInventoryData.getSetBlockSkillData(player));
-				}else if (playerdata.ZoneSetSkillFlag == true ){
-					playerdata.ZoneSetSkillFlag = false ;
-					player.sendMessage(ChatColor.RED + "範囲設置スキルOFF" ) ;
-					player.openInventory(MenuInventoryData.getSetBlockSkillData(player));
+				if(playerdata.level < BuildAssist.config.getZoneSetSkillLevel() ){
+					player.sendMessage(ChatColor.RED + "建築LVが足りません") ;
+				}else{
+					if(playerdata.ZoneSetSkillFlag == false){
+						playerdata.ZoneSetSkillFlag = true ;
+						player.sendMessage(ChatColor.RED + "範囲設置スキルON" ) ;
+						player.openInventory(MenuInventoryData.getSetBlockSkillData(player));
+					}else if (playerdata.ZoneSetSkillFlag == true ){
+						playerdata.ZoneSetSkillFlag = false ;
+						player.sendMessage(ChatColor.RED + "範囲設置スキルOFF" ) ;
+						player.openInventory(MenuInventoryData.getSetBlockSkillData(player));
+					}
 				}
 
 
@@ -351,14 +358,14 @@ public class PlayerInventoryListener implements Listener {
 				player.sendMessage(ChatColor.GREEN + "ハーフブロック設定 ：" + BuildAssist.line_up_step_str[playerdata.line_up_step_flg] ) ;
 				player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
 				player.openInventory(MenuInventoryData.getBlockLineUpData(player));
-				
+
 			} else if (itemstackcurrent.getType().equals(Material.TNT)){
 				//ブロックを並べるスキル一部ブロックを破壊して並べる設定
 				playerdata.line_up_des_flg ^= 1;
 				player.sendMessage(ChatColor.GREEN + "破壊設定 ：" + BuildAssist.line_up_off_on_str[playerdata.line_up_des_flg] ) ;
 				player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
 				player.openInventory(MenuInventoryData.getBlockLineUpData(player));
-				
+
 			} else if (itemstackcurrent.getType().equals(Material.CHEST)){
 				//マインスタックの方を優先して消費する設定
 				if(playerdata.level < BuildAssist.config.getblocklineupMinestacklevel() ){
@@ -375,8 +382,8 @@ public class PlayerInventoryListener implements Listener {
 
 	}
 
-	
-	
+
+
 	//ブロックを並べるスキル（仮）設定画面
 	@EventHandler
 	public void onPlayerClickBlockCraft(InventoryClickEvent event){
@@ -452,5 +459,5 @@ public class PlayerInventoryListener implements Listener {
 		}
 
 	}
-	
+
 }


### PR DESCRIPTION
・Lv15未満は範囲設置メニューに入れないよう変更
・プレイヤーSkullクリックで範囲設置メニューが開いていたのを変更
・土設置機能をデフォルトでONに変更
・念のためメニュー内の範囲設置スキルトグルもLv15制限に変更