### PR TITLE
1分間の建築量カウントに上限を設ける、ブロックを並べるスキルのバグ修正

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,18 +1,18 @@
+#Fly時の1分辺りの経験値消費量
 flyexp: '50'
-#
+
 #ブロックを並べるスキル
 blocklineup:
   level: '15'
   mana_mag: '0.0'
   minestack_level: '30'
 
+#範囲設置スキル
 ZoneSetSkill:
   level: '15'
 
-#
 #スキルを使って並べた時のブロックカウント倍率
 BlockCountMag: '0.2'
-
 
 # MineStackブロック一括クラフト
 minestack_BlockCraft:
@@ -20,3 +20,5 @@ minestack_BlockCraft:
   level2: '35'
   level3: '45'
   
+#ブロック設置カウントの1分上限
+BuildNum1minLimit: '100'

--- a/src/com/github/unchama/buildassist/BlockLineUp.java
+++ b/src/com/github/unchama/buildassist/BlockLineUp.java
@@ -209,6 +209,10 @@ public class BlockLineUp implements Listener{
 
 				}
 				v *= double_mag;	//ハーフ2段重ねの場合は2倍
+				//カウント対象ワールドの場合カウント値を足す
+				if( com.github.unchama.buildassist.Util.isBlockCount(player) == true){	//対象ワールドかチェック
+					playerdata.build_num_1min += ( v * BuildAssist.config.getBlockCountMag() );	//設置した数を足す
+				}
 				
 				//マインスタック優先の場合マインスタックの数を減らす
 				if( playerdata.line_up_minestack_flg == 1 && no > -1){
@@ -236,10 +240,6 @@ public class BlockLineUp implements Listener{
 //				playerdata_s.activeskilldata.mana.decreaseMana((double)(v) * mana_mag , player, playerdata_s.level);
 				player.playSound(player.getLocation(), Sound.BLOCK_STONE_PLACE, 1, 1);
 				
-				//カウント対象ワールドかチェック
-				if( com.github.unchama.buildassist.Util.isBlockCount(player) == true){
-					playerdata.totalbuildnum += ( v * BuildAssist.config.getBlockCountMag() );	//設置した数を足す
-				}
 //				player.sendMessage("v:" + v +" d:" + d);
 //				player.sendMessage("マナ:" + playerdata_s.activeskilldata.mana.getMana() );
 				

--- a/src/com/github/unchama/buildassist/BlockPlaceEventListener.java
+++ b/src/com/github/unchama/buildassist/BlockPlaceEventListener.java
@@ -37,7 +37,7 @@ public class BlockPlaceEventListener implements Listener {
 				return;
 			}
 
-			playerdata.totalbuildnum++;
+			playerdata.build_num_1min++;
 //			player.sendMessage(""+b.getType() + ":"+b.getData());
 //		}
 

--- a/src/com/github/unchama/buildassist/Config.java
+++ b/src/com/github/unchama/buildassist/Config.java
@@ -86,4 +86,9 @@ public class Config{
 		return Util.toInt(config.getString("minestack_BlockCraft.level" + lv ));
 	}
 	
+	//MineStackブロック一括クラフト開放LV
+	public int getBuildNum1minLimit() {
+		return Util.toInt(config.getString("BuildNum1minLimit" ));
+	}
+	
 }

--- a/src/com/github/unchama/buildassist/Config.java
+++ b/src/com/github/unchama/buildassist/Config.java
@@ -86,7 +86,7 @@ public class Config{
 		return Util.toInt(config.getString("minestack_BlockCraft.level" + lv ));
 	}
 	
-	//MineStackブロック一括クラフト開放LV
+	//ブロック設置カウントの1分上限
 	public int getBuildNum1minLimit() {
 		return Util.toInt(config.getString("BuildNum1minLimit" ));
 	}

--- a/src/com/github/unchama/buildassist/MinuteTaskRunnable.java
+++ b/src/com/github/unchama/buildassist/MinuteTaskRunnable.java
@@ -32,6 +32,17 @@ public class MinuteTaskRunnable extends BukkitRunnable {
 
 				int minus = -BuildAssist.config.getFlyExp();
 
+				//1分間の建築量を加算する
+//				player.sendMessage("1分の設置数:" + playerdata.build_num_1min);
+//				player.sendMessage("累計設置数:" + playerdata.totalbuildnum);
+				if( playerdata.build_num_1min > BuildAssist.config.getBuildNum1minLimit() ){
+					playerdata.totalbuildnum += BuildAssist.config.getBuildNum1minLimit();
+				}else{
+					playerdata.totalbuildnum += playerdata.build_num_1min;
+				}
+				playerdata.build_num_1min = 0;
+//				player.sendMessage("累計設置数:" + playerdata.totalbuildnum);
+				
 				playerdata.levelupdata(player);
 				playerdata.buildsave(player);
 				

--- a/src/com/github/unchama/buildassist/PlayerData.java
+++ b/src/com/github/unchama/buildassist/PlayerData.java
@@ -12,7 +12,7 @@ public class PlayerData {
 	public String name;
 	public UUID uuid;
 	public int level;
-	//ランキング算出用トータル破壊ブロック
+	//トータル設置ブロック数
 	public int totalbuildnum;
 
 	public boolean flyflag;
@@ -22,6 +22,8 @@ public class PlayerData {
 	public boolean zsSkillDirtFlag;
 	public int AREAint ;
 
+	public int build_num_1min;			//1分のブロック設置数
+	
 	//ブロックを並べるスキル設定フラグ
 	public int line_up_flg;
 	public int line_up_step_flg;
@@ -49,6 +51,8 @@ public class PlayerData {
 			line_up_step_flg = 0;
 			line_up_des_flg = 0;
 			line_up_minestack_flg = 0;
+			
+			build_num_1min = 0;
 
 		}
 		//レベルを更新

--- a/src/com/github/unchama/buildassist/PlayerRightClickListener.java
+++ b/src/com/github/unchama/buildassist/PlayerRightClickListener.java
@@ -309,7 +309,7 @@ public class PlayerRightClickListener implements Listener  {
 					player.sendMessage(ChatColor.RED + "敷き詰めスキル：処理終了" ) ;
 					
 					if( com.github.unchama.buildassist.Util.isBlockCount(player) == true){
-						playerdata.totalbuildnum += ( block_cnt * BuildAssist.config.getBlockCountMag() );	//設置した数を足す
+						playerdata.build_num_1min += ( block_cnt * BuildAssist.config.getBlockCountMag() );	//設置した数を足す
 					}
 
 					return;


### PR DESCRIPTION
1分間の建築量カウントに上限を設ける(100カウントに設定)
ブロックを並べるスキルでマインスタック優先使用を設定すると建築量がカウントされなかったバグを修正