### PR TITLE
範囲設置スキル・MineStack優先処理機能実装

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,6 +10,7 @@ blocklineup:
 #範囲設置スキル
 ZoneSetSkill:
   level: '15'
+  minestack: '30'
 
 #スキルを使って並べた時のブロックカウント倍率
 BlockCountMag: '0.2'

--- a/src/com/github/unchama/buildassist/Config.java
+++ b/src/com/github/unchama/buildassist/Config.java
@@ -91,4 +91,9 @@ public class Config{
 		return Util.toInt(config.getString("BuildNum1minLimit" ));
 	}
 	
+	//ブロック範囲設置スキルのマインスタック優先解放レベル
+	public int getZoneskillMinestacklevel(){
+		return Util.toInt(config.getString("ZoneSetSkill.minestack"));
+	}
+	
 }

--- a/src/com/github/unchama/buildassist/MenuInventoryData.java
+++ b/src/com/github/unchama/buildassist/MenuInventoryData.java
@@ -59,6 +59,13 @@ public class MenuInventoryData {
 		}else {
 			ZSSkill = "OFF" ;
 		}
+		
+		String ZSSkill_Minestack;
+		if(playerdata.zs_minestack_flag){
+			ZSSkill_Minestack = "ON";
+		}else{
+			ZSSkill_Minestack = "OFF";
+		}
 
 
 
@@ -161,7 +168,9 @@ public class MenuInventoryData {
 		skullmeta = (SkullMeta) Bukkit.getItemFactory().getItemMeta(Material.SKULL_ITEM);
 		itemstack.setDurability((short) 3);
 		skullmeta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + "「範囲設置スキル」設定画面へ");
-		lore = Arrays.asList(ChatColor.RESET + "" +  ChatColor.DARK_RED + "" + ChatColor.UNDERLINE + "クリックで移動");
+		lore = Arrays.asList(ChatColor.RESET + "" +  ChatColor.DARK_RED + "" + ChatColor.UNDERLINE + "クリックで移動"
+							,ChatColor.RESET + "" + ChatColor.GRAY + "現在の設定"
+							,ChatColor.RESET + "" + ChatColor.GRAY + "MineStack優先設定:" + ZSSkill_Minestack);
 		skullmeta.setLore(lore);
 		skullmeta.setOwner("MHF_Exclamation");
 		itemstack.setItemMeta(skullmeta);
@@ -241,6 +250,13 @@ public class MenuInventoryData {
 		}else {
 			ZSDirt = "OFF" ;
 		}
+		
+		String ZSSkill_Minestack;
+		if(playerdata.zs_minestack_flag){
+			ZSSkill_Minestack = "ON";
+		}else{
+			ZSSkill_Minestack = "OFF";
+		}
 
 		int ZSSkillA =(playerdata.AREAint) * 2 + 1;
 
@@ -273,7 +289,8 @@ public class MenuInventoryData {
 		itemmeta = Bukkit.getItemFactory().getItemMeta(Material.STONE);
 		itemmeta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + "現在の設定は以下の通りです");
 		lore = Arrays.asList(ChatColor.RESET + "" +  ChatColor.AQUA + "" + ChatColor.UNDERLINE + "スキルの使用設定：" + ZSSkill
-							,ChatColor.RESET + "" +  ChatColor.AQUA + "" + ChatColor.UNDERLINE + "スキルの範囲設定：" + ZSSkillA + "×" + ZSSkillA);
+							,ChatColor.RESET + "" +  ChatColor.AQUA + "" + ChatColor.UNDERLINE + "スキルの範囲設定：" + ZSSkillA + "×" + ZSSkillA
+							,ChatColor.RESET + "" +  ChatColor.AQUA + "" + ChatColor.UNDERLINE + "MineStack優先設定:" + ZSSkill_Minestack);
 		itemmeta.setLore(lore);
 		itemstack.setItemMeta(itemmeta);
 		inventory.setItem(13,itemstack);
@@ -345,6 +362,19 @@ public class MenuInventoryData {
 		itemstack.setItemMeta(skullmeta);
 		inventory.setItem(25,itemstack);
 
+		//35番目にMineStack優先設定を追加
+		//マインスタックの方を優先して消費する設定
+		itemstack = new ItemStack(Material.CHEST,1);
+		itemmeta = Bukkit.getItemFactory().getItemMeta(Material.CHEST);
+		itemmeta.setDisplayName(ChatColor.YELLOW + "" + ChatColor.UNDERLINE + "" + ChatColor.BOLD + "MineStack優先設定：" + ZSSkill_Minestack);
+		lore = Arrays.asList(ChatColor.RESET + "" + ChatColor.GRAY + "スキルでブロックを並べるとき"
+				, ChatColor.RESET + "" + ChatColor.GRAY + "MineStackの在庫を優先して消費します。"
+				, ChatColor.RESET + "" + ChatColor.GRAY + "建築LV" + BuildAssist.config.getZoneskillMinestacklevel() + "以上で利用可能"
+				, ChatColor.RESET + "" + ChatColor.GRAY + "クリックで切り替え"
+				);
+		itemmeta.setLore(lore);
+		itemstack.setItemMeta(itemmeta);
+		inventory.setItem(35,itemstack);
 
 		return inventory;
 	}

--- a/src/com/github/unchama/buildassist/PlayerData.java
+++ b/src/com/github/unchama/buildassist/PlayerData.java
@@ -29,6 +29,9 @@ public class PlayerData {
 	public int line_up_step_flg;
 	public int line_up_des_flg;
 	public int line_up_minestack_flg;
+	//ブロック範囲設置スキル設定フラグ
+	public boolean zs_minestack_flag;
+	
 	private BuildAssist plugin = BuildAssist.plugin;
 
 
@@ -51,6 +54,8 @@ public class PlayerData {
 			line_up_step_flg = 0;
 			line_up_des_flg = 0;
 			line_up_minestack_flg = 0;
+			
+			zs_minestack_flag = false;
 			
 			build_num_1min = 0;
 

--- a/src/com/github/unchama/buildassist/PlayerInventoryListener.java
+++ b/src/com/github/unchama/buildassist/PlayerInventoryListener.java
@@ -276,6 +276,20 @@ public class PlayerInventoryListener implements Listener {
 					player.sendMessage(ChatColor.RED + "土設置機能OFF" ) ;
 					player.openInventory(MenuInventoryData.getSetBlockSkillData(player));
 				}
+			}else if(itemstackcurrent.getType().equals(Material.CHEST)){
+				//MineStack優先設定
+				player.playSound(player.getLocation(), Sound.BLOCK_STONE_BUTTON_CLICK_ON, 1, 1);
+				if(playerdata.level < BuildAssist.config.getZoneskillMinestacklevel()){
+					player.sendMessage(ChatColor.RED + "建築LVが足りません") ;
+				}else{
+					if(playerdata.zs_minestack_flag == true){
+						playerdata.zs_minestack_flag = false;
+						player.sendMessage(ChatColor.RED + "MineStack優先設定OFF");
+					}else{
+						playerdata.zs_minestack_flag = true;
+						player.sendMessage(ChatColor.RED + "MineStack優先設定ON");
+					}
+				}
 			}
 
 		}

--- a/src/com/github/unchama/buildassist/PlayerRightClickListener.java
+++ b/src/com/github/unchama/buildassist/PlayerRightClickListener.java
@@ -18,6 +18,8 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
+import com.github.unchama.seichiassist.SeichiAssist;
+
 public class PlayerRightClickListener implements Listener  {
 	HashMap<UUID, PlayerData> playermap = BuildAssist.playermap;
 
@@ -36,6 +38,7 @@ public class PlayerRightClickListener implements Listener  {
 		EquipmentSlot equipmentslot = event.getHand();
 		//プレイヤーデータ
 		PlayerData playerdata = BuildAssist.playermap.get(uuid);
+		com.github.unchama.seichiassist.data.PlayerData playerdata_s = SeichiAssist.playermap.get(uuid);
 
 		//プレイヤーデータが無い場合は処理終了
 		if(playerdata == null){
@@ -123,6 +126,13 @@ public class PlayerRightClickListener implements Listener  {
 
 					//
 					int block_cnt = 0;
+					
+					//MineStack No.用
+					int no = -1;
+					
+					//MineStack設置できる最大量取得しておく
+					int max = 0;
+					
 					//オフハンドアイテムと、範囲内のブロックに一致する物があるかどうか判別
 					//同じ物がない場合・同じ物が3か所以上のY軸で存在する場合→SetReady = false
 					for(;searchY < playerlocy + 2 ;){
@@ -224,6 +234,47 @@ public class PlayerRightClickListener implements Listener  {
 									player.sendMessage(ChatColor.RED + "付近に誰かの保護がかかっているようです" ) ;
 									break;
 								}else {
+									//TODO:ここでMineStackの処理。flagがtrueならInvに関係なしにここに持ってくる
+									if(playerdata.zs_minestack_flag == true)minestack:{//label指定は基本的に禁じ手だが、今回は後付けなので使わせてもらう。(解読性向上のため、1箇所のみの利用)
+										for(int cnt = 0 ; cnt < SeichiAssist.minestacklist.size() ; cnt++ ){
+											if(offhanditem.getType().equals(SeichiAssist.minestacklist.get(cnt).getMaterial()) && 
+													offhanditem.getData().getData() == SeichiAssist.minestacklist.get(cnt).getDurability()){
+												no = cnt;
+												break;
+												//no:設置するブロック・max:設置できる最大量
+											}
+										}
+										if(no > 0){
+											//設置するブロックがMineStackに登録済み
+											//1引く
+											if(playerdata_s.minestack.getNum(no) > 0){
+												player.sendMessage("MineStackよりブロック消費");//TODO:DEBUG
+												player.sendMessage("MineStackブロック残量(前):" + playerdata_s.minestack.getNum(no));//TODO:DEBUG
+												playerdata_s.minestack.setNum(no, playerdata_s.minestack.getNum(no) - 1);
+												player.sendMessage("MineStackブロック残量(後):" + playerdata_s.minestack.getNum(no));
+												
+												//設置処理
+												player.getWorld().getBlockAt(setblockX,setblockY,setblockZ).setType(offhanditem.getType());
+												player.getWorld().getBlockAt(setblockX,setblockY,setblockZ).setData(offhanditem.getData().getData());
+												
+												//ブロックカウント
+												block_cnt++;
+												
+												//あとの設定
+												setblockX ++ ;
+
+												if(setblockX > playerlocx + AREAint){
+													setblockX = setblockX - AREAintB ;
+													setblockZ ++ ;
+												}
+												continue;
+											}else{
+												player.sendMessage("MineStackのブロックがありません。インベントリより消費します。");//TODO:DEBUG
+												break minestack;//minestack処理はなかったことにして次のfor分に飛ぶ。(label:minestackだけから抜ける)
+											}
+										}
+									}
+									
 
 								//インベントリの左上から一つずつ確認する。
 								//※一度「該当アイテムなし」と判断したスロットは次回以降スキップする様に組んであるゾ

--- a/src/com/github/unchama/buildassist/PlayerRightClickListener.java
+++ b/src/com/github/unchama/buildassist/PlayerRightClickListener.java
@@ -234,7 +234,7 @@ public class PlayerRightClickListener implements Listener  {
 									player.sendMessage(ChatColor.RED + "付近に誰かの保護がかかっているようです" ) ;
 									break;
 								}else {
-									//TODO:ここでMineStackの処理。flagがtrueならInvに関係なしにここに持ってくる
+									//ここでMineStackの処理。flagがtrueならInvに関係なしにここに持ってくる
 									if(playerdata.zs_minestack_flag == true)minestack:{//label指定は基本的に禁じ手だが、今回は後付けなので使わせてもらう。(解読性向上のため、1箇所のみの利用)
 										for(int cnt = 0 ; cnt < SeichiAssist.minestacklist.size() ; cnt++ ){
 											if(offhanditem.getType().equals(SeichiAssist.minestacklist.get(cnt).getMaterial()) && 
@@ -248,10 +248,10 @@ public class PlayerRightClickListener implements Listener  {
 											//設置するブロックがMineStackに登録済み
 											//1引く
 											if(playerdata_s.minestack.getNum(no) > 0){
-												player.sendMessage("MineStackよりブロック消費");//TODO:DEBUG
-												player.sendMessage("MineStackブロック残量(前):" + playerdata_s.minestack.getNum(no));//TODO:DEBUG
+												//player.sendMessage("MineStackよりブロック消費");
+												//player.sendMessage("MineStackブロック残量(前):" + playerdata_s.minestack.getNum(no));
 												playerdata_s.minestack.setNum(no, playerdata_s.minestack.getNum(no) - 1);
-												player.sendMessage("MineStackブロック残量(後):" + playerdata_s.minestack.getNum(no));
+												//player.sendMessage("MineStackブロック残量(後):" + playerdata_s.minestack.getNum(no));
 												
 												//設置処理
 												player.getWorld().getBlockAt(setblockX,setblockY,setblockZ).setType(offhanditem.getType());
@@ -269,7 +269,7 @@ public class PlayerRightClickListener implements Listener  {
 												}
 												continue;
 											}else{
-												player.sendMessage("MineStackのブロックがありません。インベントリより消費します。");//TODO:DEBUG
+												//player.sendMessage("MineStackのブロックがありません。インベントリより消費します。");
 												break minestack;//minestack処理はなかったことにして次のfor分に飛ぶ。(label:minestackだけから抜ける)
 											}
 										}


### PR DESCRIPTION
デバッグ不十分です(確認すべてはできてません。石・石ハーフは大丈夫なことを確認しました。)
非推奨のlabelを使用してます。解読性のため1か所のみの利用に止めてます。使用しないとコードが複雑化するので使わせてもらいました。(PlayerRightClickEvent.java#238)

・configにてminestackの使用可能レベルを変更できるようにしました。
・MineStack優先設定のボタン・表示を追加しました。
・MineStackに在庫がない時、インベントリより消費するようにしてあります。

以上、疑問点・改善点等ありましたらお知らせください。