### PR TITLE
[FIX]表記ゆれの修正

### DIFF
--- a/src/com/github/unchama/buildassist/PlayerData.java
+++ b/src/com/github/unchama/buildassist/PlayerData.java
@@ -79,7 +79,7 @@ public class PlayerData {
 				}
 				i++;
 				if( (i+1) == BuildAssist.levellist.size()){
-					player.sendMessage(ChatColor.GOLD+"最大LVに到達したよ(`･ω･´)");
+					player.sendMessage(ChatColor.GOLD+"最大Lvに到達したよ(`･ω･´)");
 				}
 			}
 			level = i;


### PR DESCRIPTION
建築レベル99→100のレベルアップ時の表記ゆれを修正